### PR TITLE
Added checking for accessors methods to prevent linking to unexisting shema.

### DIFF
--- a/src/Definitions/DefinitionGenerator.php
+++ b/src/Definitions/DefinitionGenerator.php
@@ -183,10 +183,10 @@ class DefinitionGenerator {
                         $type = $returnType->getName();
 
                         if (Str::contains($type, '\\')) {
-                            $data = [
-                                'type' => 'object',
-                                '$ref' => '#/components/schemas/' . last(explode('\\', $type)),
-                            ];
+                            $data = ['type' => 'object'];
+                            if (is_subclass_of($type, Model::class)) {
+                                $data['$ref'] = '#/components/schemas/' . last(explode('\\', $type));
+                            }
                         } else {
                             $data['type'] = $type;
                             $this->addExampleKey($data);


### PR DESCRIPTION
Fixed bug when $ref link was generated to an unexisting schema when return type was an object of class not extended of the model.
