### PR TITLE
Fix column type int

### DIFF
--- a/src/Definitions/DefinitionGenerator.php
+++ b/src/Definitions/DefinitionGenerator.php
@@ -304,6 +304,7 @@ class DefinitionGenerator
                 ];
                 break;
             case 'serial':
+            case 'int':
             case 'integer':
             case 'mediumint':
             case 'smallint':


### PR DESCRIPTION
If column type is `int` then it will not be properly formatted inside Swagger json.

Before:
```
"id": {
      "type": "object",
      "nullable": true,
      "additionalProperties": true,
      "description": "int"
  },
  "user_id": {
      "type": "object",
      "nullable": true,
      "additionalProperties": true,
      "description": "int"
  },
```

After
```
"id": {
      "type": "integer"
  },
  "user_id": {
      "type": "integer"
  },
```